### PR TITLE
refactor to allow metric collection to be split between multiple tasks

### DIFF
--- a/kubestate/client.go
+++ b/kubestate/client.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	. "github.com/intelsdi-x/snap-plugin-utilities/logger"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 	v1batch "k8s.io/client-go/pkg/apis/batch/v1"
@@ -50,18 +51,35 @@ var newClient = func(incluster bool, kubeconfigpath string) (*Client, error) {
 	return c, nil
 }
 
-func (c *Client) GetPods() (*v1.PodList, error) {
-	return c.clientset.Core().Pods("").List(v1.ListOptions{})
+func (c *Client) GetPods(namespace, node string) (*v1.PodList, error) {
+	opts := v1.ListOptions{}
+	if node != "*" {
+		opts.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", node).String()
+	}
+	if namespace == "*" {
+		namespace = ""
+	}
+	return c.clientset.Core().Pods(namespace).List(opts)
 }
 
-func (c *Client) GetNodes() (*v1.NodeList, error) {
+func (c *Client) GetNodes(node string) (*v1.NodeList, error) {
+	opts := v1.ListOptions{}
+	if node != "*" {
+		opts.FieldSelector = fields.OneTermEqualSelector("metadata.name", node).String()
+	}
 	return c.clientset.Core().Nodes().List(v1.ListOptions{})
 }
 
-func (c *Client) GetDeployments() (*v1beta1.DeploymentList, error) {
-	return c.clientset.Extensions().Deployments("").List(v1.ListOptions{})
+func (c *Client) GetDeployments(namespace string) (*v1beta1.DeploymentList, error) {
+	if namespace == "*" {
+		namespace = ""
+	}
+	return c.clientset.Extensions().Deployments(namespace).List(v1.ListOptions{})
 }
 
-func (c *Client) GetJobs() (*v1batch.JobList, error) {
-	return c.clientset.BatchClient.Jobs("").List(v1.ListOptions{})
+func (c *Client) GetJobs(namespace string) (*v1batch.JobList, error) {
+	if namespace == "*" {
+		namespace = ""
+	}
+	return c.clientset.BatchClient.Jobs(namespace).List(v1.ListOptions{})
 }


### PR DESCRIPTION
- For large k8s clusters, it is not possible to collect all metrics
  in one go.  This commit allows metrics to be collected on a per
  namespace and or per node basis.
- Additionally, by allowing per node metrics each node in the cluster
   can collect its own pod and container metrics.